### PR TITLE
Allow false to show in results.

### DIFF
--- a/src/components/CompiledCode.js
+++ b/src/components/CompiledCode.js
@@ -11,7 +11,7 @@ const CompiledCode = ({ codeString }) => {
       presets: ['es2015', 'react', 'stage-0']
     }).code);
 
-    result = result === 'use strict' ? '' : result;
+    result = result === 'use strict' ? undefined : result;
     /* eslint-enable */
   } catch (ex) {
     error = ex.toString();
@@ -20,7 +20,7 @@ const CompiledCode = ({ codeString }) => {
   return (
     <pre className="p2 bg-lighten-4" style={ styles.base }>
       {
-        result ? stringify(result) : <div className="red">{ error }</div>
+        !error ? stringify(result) : <div className="red">{ error }</div>
       }
     </pre>
   );


### PR DESCRIPTION
- Return all results, except when there is an error.
- Return `undefined` when Babel returns "use strict" to avoid seeing empty quotes when there is no code in left pane.

https://immutable-repl.herokuapp.com/?q=MSA9PT0gMjs%3D
